### PR TITLE
Unify interpreter state into TwaddleContext

### DIFF
--- a/twaddle/interpreter/block_attributes.py
+++ b/twaddle/interpreter/block_attributes.py
@@ -1,49 +1,30 @@
+from dataclasses import dataclass
 from typing import Optional
 
 from twaddle.interpreter.formatting_object import FormattingStrategy
 from twaddle.parser.nodes import RootNode
 
 
+@dataclass
 class BlockAttributes:
-    def __init__(self):
-        self.repetitions: int = 1
-        self.separator: RootNode | None = None
-        self.first: RootNode | None = None
-        self.last: RootNode | None = None
-        self.synchronizer: str | None = None
-        self.synchronizer_type: str | None = None
-        self.hidden: bool = False
-        self.reverse: bool = False
-        self.save_as: Optional[str] = None
-        self.copy_as: Optional[str] = None
-        self.abbreviate: bool = False
-        self.abbreviation_case: Optional[FormattingStrategy] = None
-        self.max_decimals: Optional[int] = None
-        self.while_predicate: Optional[RootNode] = None
-        self.while_iteration = 0
-        self.max_while_iterations = 100
-
-
-class BlockAttributeManager:
-    def __init__(self):
-        self.saved_blocks = dict[str, RootNode]()
-        self.current_attributes = BlockAttributes()
-
-    def get_attributes(self) -> BlockAttributes:
-        attributes = self.current_attributes
-        self.current_attributes = BlockAttributes()
-        return attributes
+    repetitions: int = 1
+    separator: Optional[RootNode] = None
+    first: Optional[RootNode] = None
+    last: Optional[RootNode] = None
+    synchronizer: Optional[str] = None
+    synchronizer_type: Optional[str] = None
+    hidden: bool = False
+    reverse: bool = False
+    save_as: Optional[str] = None
+    copy_as: Optional[str] = None
+    abbreviate: bool = False
+    abbreviation_case: Optional[FormattingStrategy] = None
+    max_decimals: Optional[int] = None
+    while_predicate: Optional[RootNode] = None
+    while_iteration = 0
+    max_while_iterations = 100
 
     def set_synchronizer(self, args: list[str]):
-        self.current_attributes.synchronizer = args[0]
+        self.synchronizer = args[0]
         if len(args) > 1:
-            self.current_attributes.synchronizer_type = args[1]
-
-    def save_block(self, name: str):
-        self.current_attributes.save_as = name
-
-    def copy_block(self, name: str):
-        self.current_attributes.copy_as = name
-
-    def clear(self):
-        self.current_attributes = BlockAttributes()
+            self.synchronizer_type = args[1]

--- a/twaddle/interpreter/context.py
+++ b/twaddle/interpreter/context.py
@@ -1,0 +1,40 @@
+from dataclasses import dataclass, field
+
+from twaddle.exceptions import TwaddleInterpreterException
+from twaddle.interpreter.block_attributes import BlockAttributes
+from twaddle.interpreter.synchronizer import Synchronizer, sync_types
+from twaddle.lookup.lookup_manager import LookupManager
+
+
+@dataclass
+class TwaddleContext:
+    lookup_manager: LookupManager = field(default_factory=LookupManager)
+    block_attributes: BlockAttributes = field(default_factory=BlockAttributes)
+    synchronizers: dict[str, Synchronizer] = field(default_factory=dict)
+
+    def reset_for_new_sentence(self):
+        pass
+
+    def consume_block_attributes(self) -> BlockAttributes:
+        attrs = self.block_attributes
+        self.block_attributes = BlockAttributes()
+        return attrs
+
+    def synchronizer_exists(self, name: str) -> bool:
+        return name in self.synchronizers
+
+    def create_synchronizer(
+        self, name: str, sync_type: str, length: int
+    ) -> Synchronizer:
+        self.synchronizers[name] = sync_types[sync_type](length)
+        return self.synchronizers[name]
+
+    def get_synchronizer(self, name: str) -> Synchronizer:
+        if not self.synchronizer_exists(name):
+            raise TwaddleInterpreterException(
+                f"[TwaddleContext.get_synchronizer] tried to access non-existing synchronizer {name}"
+            )
+        return self.synchronizers[name]
+
+    def clear(self):
+        self.synchronizers.clear()

--- a/twaddle/interpreter/context.py
+++ b/twaddle/interpreter/context.py
@@ -1,19 +1,47 @@
 from dataclasses import dataclass, field
+from typing import Optional
 
 from twaddle.exceptions import TwaddleInterpreterException
 from twaddle.interpreter.block_attributes import BlockAttributes
+from twaddle.interpreter.formatter import Formatter
 from twaddle.interpreter.synchronizer import Synchronizer, sync_types
 from twaddle.lookup.lookup_manager import LookupManager
+from twaddle.parser.nodes import BlockNode
 
 
 @dataclass
 class TwaddleContext:
+    persistent_labels: bool = False
+    persistent_synchronizers: bool = False
+    persistent_patterns: bool = False
+    persistent_clipboard: bool = False
+    strict_mode: bool = False
+
+    saved_patterns = dict[str, BlockNode]()
+    copied_blocks = dict[str, Formatter]()
     lookup_manager: LookupManager = field(default_factory=LookupManager)
     block_attributes: BlockAttributes = field(default_factory=BlockAttributes)
     synchronizers: dict[str, Synchronizer] = field(default_factory=dict)
 
+    current_regex_match: Optional[str] = None
+
     def reset_for_new_sentence(self):
-        pass
+        if not self.persistent_patterns:
+            self.saved_patterns.clear()
+        if not self.persistent_clipboard:
+            self.copied_blocks.clear()
+        if not self.persistent_synchronizers:
+            self.clear_synchronizers()
+        if not self.persistent_labels:
+            self.lookup_manager.clear_labels()
+        self.consume_block_attributes()
+
+    def force_clear(self):
+        self.saved_patterns.clear()
+        self.copied_blocks.clear()
+        self.clear_synchronizers()
+        self.lookup_manager.clear_labels()
+        self.consume_block_attributes()
 
     def consume_block_attributes(self) -> BlockAttributes:
         attrs = self.block_attributes
@@ -36,5 +64,5 @@ class TwaddleContext:
             )
         return self.synchronizers[name]
 
-    def clear(self):
+    def clear_synchronizers(self):
         self.synchronizers.clear()

--- a/twaddle/interpreter/formatter.py
+++ b/twaddle/interpreter/formatter.py
@@ -1,6 +1,6 @@
 import re
 from functools import singledispatchmethod
-from typing import Self, Type
+from typing import Optional, Self
 
 from twaddle.exceptions import TwaddleInterpreterException
 from twaddle.interpreter.formatting_object import (
@@ -10,7 +10,7 @@ from twaddle.interpreter.formatting_object import (
     PlainText,
     StrategyChange,
 )
-from twaddle.parser.nodes import IndefiniteArticleNode, Node
+from twaddle.parser.nodes import IndefiniteArticleNode
 
 
 class Formatter:
@@ -18,25 +18,25 @@ class Formatter:
     alphabetic_regex = re.compile(r"[^\W_]+", re.UNICODE)
 
     def __init__(self):
-        self.output_stack = list[Node | FormattingObject]()
+        self.output_stack = list[FormattingObject]()
         self.sentence = str()
         self.current_strategy = FormattingStrategy.NONE
         self.indefinite_article_waiting = False
 
     def _reset_(self):
-        self.output_stack = list[Node | FormattingObject]()
+        self.output_stack = list[FormattingObject]()
         self.sentence = str()
         self.current_strategy = FormattingStrategy.NONE
         self.indefinite_article_waiting = False
 
     @classmethod
-    def from_text(cls, text: str) -> Self:
+    def from_text(cls, text: str) -> "Formatter":
         formatter = Formatter()
         formatter.append(text)
         return formatter
 
     @singledispatchmethod
-    def append(self, arg) -> Self:
+    def append(self, arg) -> "Formatter":
         if arg is None:
             formatter = Formatter()
             return formatter
@@ -51,19 +51,22 @@ class Formatter:
         self.output_stack.append(PlainText(previous, item))
         if self.indefinite_article_waiting:
             self._replace_indefinite_articles(item)
-        return
+        return self
 
     @append.register(FormattingStrategy)
     def _(self, item: FormattingStrategy) -> Self:
         self.output_stack.append(StrategyChange(self._get_previous_object_(), item))
+        return self
 
     @append.register(IndefiniteArticleNode)
     def _(self, item: IndefiniteArticleNode) -> Self:
         self.add_indefinite_article(item.default_upper)
+        return self
 
     @append.register(IndefiniteArticle)
     def _(self, item: IndefiniteArticle) -> Self:
         self.add_indefinite_article(item.default_upper)
+        return self
 
     @append.register(PlainText)
     def _(self, item: PlainText) -> Self:
@@ -71,16 +74,18 @@ class Formatter:
         self.output_stack.append(PlainText(previous, item.text))
         if self.indefinite_article_waiting:
             self._replace_indefinite_articles(item.text)
+        return self
 
     @append.register(FormattingObject)
     def _(self, item: FormattingObject) -> Self:
         item.previous = self._get_previous_object_()
         self.output_stack.append(item)
+        return self
 
     def append_formatter(self, formatter: Self):
         self.output_stack += formatter.output_stack
 
-    def _get_previous_object_(self) -> Type[FormattingObject] | None:
+    def _get_previous_object_(self) -> Optional[FormattingObject]:
         if len(self.output_stack):
             return self.output_stack[-1]
         return None

--- a/twaddle/interpreter/formatting_object.py
+++ b/twaddle/interpreter/formatting_object.py
@@ -1,5 +1,5 @@
 from enum import Enum, auto
-from typing import Type
+from typing import Optional
 
 
 class FormattingStrategy(Enum):
@@ -11,7 +11,7 @@ class FormattingStrategy(Enum):
 
 
 class FormattingObject:
-    def __init__(self, previous):
+    def __init__(self, previous: Optional["FormattingObject"]):
         self.previous = None
         if previous is not None:
             self.previous = previous
@@ -20,20 +20,22 @@ class FormattingObject:
 
 
 class PlainText(FormattingObject):
-    def __init__(self, previous: Type[FormattingObject], text: str):
+    def __init__(self, previous: Optional[FormattingObject], text: str):
         FormattingObject.__init__(self, previous)
         self.text = text
 
 
 class StrategyChange(FormattingObject):
-    def __init__(self, previous: Type[FormattingObject], strategy: FormattingStrategy):
+    def __init__(
+        self, previous: Optional[FormattingObject], strategy: FormattingStrategy
+    ):
         FormattingObject.__init__(self, previous)
         self.strategy = strategy
 
 
 class IndefiniteArticle(FormattingObject):
     def __init__(
-        self, previous: Type[FormattingObject], default_upper_case: bool = False
+        self, previous: Optional[FormattingObject], default_upper_case: bool = False
     ):
         FormattingObject.__init__(self, previous)
         self.default_upper = default_upper_case

--- a/twaddle/interpreter/function_definitions.py
+++ b/twaddle/interpreter/function_definitions.py
@@ -3,7 +3,7 @@ from random import randint
 from typing import Optional
 
 from twaddle.exceptions import TwaddleFunctionException
-from twaddle.interpreter.block_attributes import BlockAttributeManager
+from twaddle.interpreter.context import TwaddleContext
 from twaddle.interpreter.formatting_object import FormattingStrategy
 from twaddle.interpreter.regex_state import RegexState
 from twaddle.parser.nodes import RootNode
@@ -55,7 +55,7 @@ def _format_number(value: int | float, max_decimals: Optional[int]) -> str:
 
 def repeat(
     evaluated_args: list[str],
-    block_attribute_manager: BlockAttributeManager,
+    context: TwaddleContext,
     _raw_args: list[RootNode],
 ):
     if len(evaluated_args) < 1:
@@ -63,110 +63,100 @@ def repeat(
             "[function_definitions#repeat] repeat requires exactly one argument"
         )
     repetitions = int(evaluated_args[0])
-    block_attribute_manager.current_attributes.repetitions = repetitions
+    context.block_attributes.repetitions = repetitions
 
 
 def separator(
     _evaluated_args: list[str],
-    block_attribute_manager: BlockAttributeManager,
+    context: TwaddleContext,
     raw_args: list[RootNode],
 ):
     if len(raw_args) < 1:
         raise TwaddleFunctionException(
             "[function_definitions#separator] separator requires exactly one argument"
         )
-    block_attribute_manager.current_attributes.separator = raw_args[0]
+    context.block_attributes.separator = raw_args[0]
 
 
 def first(
     _evaluated_args: list[str],
-    block_attribute_manager: BlockAttributeManager,
+    context: TwaddleContext,
     raw_args: list[RootNode],
 ):
     if len(raw_args) < 1:
         raise TwaddleFunctionException(
             "[function_definitions#first] first requires exactly one argument"
         )
-    block_attribute_manager.current_attributes.first = raw_args[0]
+    context.block_attributes.first = raw_args[0]
 
 
 def last(
     _evaluated_args: list[str],
-    block_attribute_manager: BlockAttributeManager,
+    context: TwaddleContext,
     raw_args: list[RootNode],
 ):
     if len(raw_args) < 1:
         raise TwaddleFunctionException(
             "[function_definitions#last] last requires exactly one argument"
         )
-    block_attribute_manager.current_attributes.last = raw_args[0]
+    context.block_attributes.last = raw_args[0]
 
 
 def save(
     evaluated_args: list[str],
-    block_attribute_manager: BlockAttributeManager,
+    context: TwaddleContext,
     _raw_args: list[RootNode],
 ):
     if len(evaluated_args) < 1:
         raise TwaddleFunctionException(
             "[function_definitions#save] save requires exactly one argument"
         )
-    block_attribute_manager.save_block(evaluated_args[0])
+    context.block_attributes.save_as = evaluated_args[0]
 
 
 def copy(
     evaluated_args: list[str],
-    block_attribute_manager: BlockAttributeManager,
+    context: TwaddleContext,
     _raw_args: list[RootNode],
 ):
     if len(evaluated_args) < 1:
         raise TwaddleFunctionException(
             "[function_definitions#copy] copy requires exactly one argument"
         )
-    block_attribute_manager.copy_block(evaluated_args[0])
+    context.block_attributes.copy_as = evaluated_args[0]
 
 
 def sync(
     evaluated_args: list[str],
-    block_attribute_manager: BlockAttributeManager,
+    context: TwaddleContext,
     _raw_args: list[RootNode],
 ):
     if len(evaluated_args) < 1:
         raise TwaddleFunctionException(
             "[function_definitions#sync] sync requires at least one argument"
         )
-    block_attribute_manager.set_synchronizer(evaluated_args)
+    context.block_attributes.set_synchronizer(evaluated_args)
 
 
 def abbreviate(
     evaluated_args: list[str],
-    block_attribute_manager: BlockAttributeManager,
+    context: TwaddleContext,
     _raw_args: list[RootNode],
 ):
-    block_attribute_manager.current_attributes.abbreviate = True
+    context.block_attributes.abbreviate = True
     if len(evaluated_args) == 0:
-        block_attribute_manager.current_attributes.abbreviation_case = (
-            FormattingStrategy.UPPER
-        )
+        context.block_attributes.abbreviation_case = FormattingStrategy.UPPER
         return
     case = evaluated_args[0].strip().lower()
     match case:
         case "retain":
-            block_attribute_manager.current_attributes.abbreviation_case = (
-                FormattingStrategy.NONE
-            )
+            context.block_attributes.abbreviation_case = FormattingStrategy.NONE
         case "upper":
-            block_attribute_manager.current_attributes.abbreviation_case = (
-                FormattingStrategy.UPPER
-            )
+            context.block_attributes.abbreviation_case = FormattingStrategy.UPPER
         case "lower":
-            block_attribute_manager.current_attributes.abbreviation_case = (
-                FormattingStrategy.LOWER
-            )
+            context.block_attributes.abbreviation_case = FormattingStrategy.LOWER
         case "first":
-            block_attribute_manager.current_attributes.abbreviation_case = (
-                FormattingStrategy.TITLE
-            )
+            context.block_attributes.abbreviation_case = FormattingStrategy.TITLE
         case _:
             raise TwaddleFunctionException(
                 "[function_definitions#abbreviate] invalid case " f"argument '{case}'"
@@ -175,7 +165,7 @@ def abbreviate(
 
 def case(
     evaluated_args: list[str],
-    _block_attribute_manager: BlockAttributeManager,
+    _context: TwaddleContext,
     _raw_args: list[RootNode],
 ):
     if len(evaluated_args) < 1:
@@ -201,7 +191,7 @@ def case(
 # noinspection PyUnusedLocal
 def match(
     _evaluated_args: list[str],
-    _block_attribute_manager: BlockAttributeManager,
+    _context: TwaddleContext,
     _raw_args: list[RootNode],
 ):
     return RegexState.match
@@ -209,7 +199,7 @@ def match(
 
 def rand(
     evaluated_args: list[str],
-    _block_attribute_manager: BlockAttributeManager,
+    _context: TwaddleContext,
     _raw_args: list[RootNode],
 ) -> str:
     if len(evaluated_args) != 2:
@@ -223,24 +213,24 @@ def rand(
 
 def reverse(
     _evaluated_args: list[str],
-    block_attribute_manager: BlockAttributeManager,
+    context: TwaddleContext,
     _raw_args: list[RootNode],
 ):
-    block_attribute_manager.current_attributes.reverse = True
+    context.block_attributes.reverse = True
 
 
 def hide(
     _evaluated_args: list[str],
-    block_attribute_manager: BlockAttributeManager,
+    context: TwaddleContext,
     _raw_args: list[RootNode],
 ) -> str:
-    block_attribute_manager.current_attributes.hidden = True
+    context.block_attributes.hidden = True
     return ""
 
 
 def add(
     evaluated_args: list[str],
-    block_attribute_manager: BlockAttributeManager,
+    context: TwaddleContext,
     _raw_args: list[RootNode],
 ):
     if len(evaluated_args) < 2:
@@ -248,14 +238,12 @@ def add(
             "[function_definitions#add] add requires at least two numbers"
         )
     parsed_numbers = _parse_numbers(evaluated_args)
-    return _format_number(
-        sum(parsed_numbers), block_attribute_manager.current_attributes.max_decimals
-    )
+    return _format_number(sum(parsed_numbers), context.block_attributes.max_decimals)
 
 
 def subtract(
     evaluated_args: list[str],
-    block_attribute_manager: BlockAttributeManager,
+    context: TwaddleContext,
     _raw_args: list[RootNode],
 ):
     if len(evaluated_args) < 2:
@@ -264,14 +252,12 @@ def subtract(
         )
     parsed_numbers = _parse_numbers(evaluated_args)
     parsed_numbers = [parsed_numbers[0]] + [-value for value in parsed_numbers[1:]]
-    return _format_number(
-        sum(parsed_numbers), block_attribute_manager.current_attributes.max_decimals
-    )
+    return _format_number(sum(parsed_numbers), context.block_attributes.max_decimals)
 
 
 def multiply(
     evaluated_args: list[str],
-    block_attribute_manager: BlockAttributeManager,
+    context: TwaddleContext,
     _raw_args: list[RootNode],
 ):
     if len(evaluated_args) < 2:
@@ -279,14 +265,12 @@ def multiply(
             "[function_definitions#multiply] multiply requires at least two numbers"
         )
     parsed_numbers = _parse_numbers(evaluated_args)
-    return _format_number(
-        prod(parsed_numbers), block_attribute_manager.current_attributes.max_decimals
-    )
+    return _format_number(prod(parsed_numbers), context.block_attributes.max_decimals)
 
 
 def divide(
     evaluated_args: list[str],
-    block_attribute_manager: BlockAttributeManager,
+    context: TwaddleContext,
     _raw_args: list[RootNode],
 ):
     if len(evaluated_args) != 2:
@@ -300,7 +284,7 @@ def divide(
         )
     return _format_number(
         parsed_numbers[0] / parsed_numbers[1],
-        block_attribute_manager.current_attributes.max_decimals,
+        context.block_attributes.max_decimals,
     )
 
 
@@ -314,7 +298,7 @@ def boolean_helper(evaluated_arg: str) -> bool:
 
 def boolean(
     evaluated_args: list[str],
-    _block_attribute_manager: BlockAttributeManager,
+    _context: TwaddleContext,
     _raw_args: list[RootNode],
 ) -> str:
     if len(evaluated_args) != 1:
@@ -327,7 +311,7 @@ def boolean(
 
 def less_than(
     evaluated_args: list[str],
-    _block_attribute_manager: BlockAttributeManager,
+    _context: TwaddleContext,
     _raw_args: list[RootNode],
 ) -> str:
     if len(evaluated_args) != 2:
@@ -340,7 +324,7 @@ def less_than(
 
 def greater_than(
     evaluated_args: list[str],
-    _block_attribute_manager: BlockAttributeManager,
+    _context: TwaddleContext,
     _raw_args: list[RootNode],
 ) -> str:
     if len(evaluated_args) != 2:
@@ -353,7 +337,7 @@ def greater_than(
 
 def equal_to(
     evaluated_args: list[str],
-    _block_attribute_manager: BlockAttributeManager,
+    _context: TwaddleContext,
     _raw_args: list[RootNode],
 ) -> str:
     if len(evaluated_args) != 2:
@@ -369,7 +353,7 @@ def equal_to(
 
 def logical_and(
     evaluated_args: list[str],
-    _block_attribute_manager: BlockAttributeManager,
+    _context: TwaddleContext,
     _raw_args: list[RootNode],
 ) -> str:
     if len(evaluated_args) != 2:
@@ -382,7 +366,7 @@ def logical_and(
 
 def logical_not(
     evaluated_args: list[str],
-    _block_attribute_manager: BlockAttributeManager,
+    _context: TwaddleContext,
     _raw_args: list[RootNode],
 ) -> str:
     if len(evaluated_args) != 1:
@@ -395,7 +379,7 @@ def logical_not(
 
 def logical_or(
     evaluated_args: list[str],
-    _block_attribute_manager: BlockAttributeManager,
+    _context: TwaddleContext,
     _raw_args: list[RootNode],
 ) -> str:
     if len(evaluated_args) != 2:
@@ -408,7 +392,7 @@ def logical_or(
 
 def logical_xor(
     evaluated_args: list[str],
-    _block_attribute_manager: BlockAttributeManager,
+    _context: TwaddleContext,
     _raw_args: list[RootNode],
 ) -> str:
     if len(evaluated_args) != 2:
@@ -421,7 +405,7 @@ def logical_xor(
 
 def while_loop(
     evaluated_args: list[str],
-    block_attribute_manager: BlockAttributeManager,
+    context: TwaddleContext,
     raw_args: list[RootNode],
 ):
     if len(raw_args) not in [1, 2]:
@@ -436,13 +420,11 @@ def while_loop(
                     "[function_definitions#while] max iterations must be int,"
                     f" got {raw_args[1]}, evaluated to {evaluated_args[1]}"
                 )
-            block_attribute_manager.current_attributes.max_while_iterations = (
-                max_iterations
-            )
+            context.block_attributes.max_while_iterations = max_iterations
         except TwaddleFunctionException:
             raise TwaddleFunctionException(
                 "[function_definitions#while] max iterations must be int,"
                 f" got {raw_args[1]}, evaluated to {evaluated_args[1]}"
             )
 
-    block_attribute_manager.current_attributes.while_predicate = raw_args[0]
+    context.block_attributes.while_predicate = raw_args[0]

--- a/twaddle/interpreter/function_definitions.py
+++ b/twaddle/interpreter/function_definitions.py
@@ -5,7 +5,6 @@ from typing import Optional
 from twaddle.exceptions import TwaddleFunctionException
 from twaddle.interpreter.context import TwaddleContext
 from twaddle.interpreter.formatting_object import FormattingStrategy
-from twaddle.interpreter.regex_state import RegexState
 from twaddle.parser.nodes import RootNode
 
 
@@ -191,10 +190,10 @@ def case(
 # noinspection PyUnusedLocal
 def match(
     _evaluated_args: list[str],
-    _context: TwaddleContext,
+    context: TwaddleContext,
     _raw_args: list[RootNode],
 ):
-    return RegexState.match
+    return context.current_regex_match if context.current_regex_match else ""
 
 
 def rand(

--- a/twaddle/interpreter/interpreter.py
+++ b/twaddle/interpreter/interpreter.py
@@ -10,7 +10,6 @@ from twaddle.interpreter.context import TwaddleContext
 from twaddle.interpreter.formatter import Formatter
 from twaddle.interpreter.function_definitions import boolean_helper
 from twaddle.interpreter.function_dict import function_definitions
-from twaddle.interpreter.regex_state import RegexState
 from twaddle.interpreter.synchronizer import Synchronizer
 from twaddle.lookup.lookup_dictionary import LookupDictionary
 from twaddle.lookup.lookup_manager import LookupManager
@@ -92,18 +91,19 @@ class Interpreter:
         persistent_clipboard: bool = False,
         strict_mode: bool = False,
     ):
-        self.context = TwaddleContext(lookup_manager=lookup_manager)
-        self.persistent_labels = persistent_labels
-        self.persistent_synchronizers = persistent_synchronizers
-        self.persistent_patterns = persistent_patterns
-        self.persistent_clipboard = persistent_clipboard
-        self.context.lookup_manager = lookup_manager
-        self.saved_patterns = dict[str, BlockNode]()
-        self.copied_blocks = dict[str, Formatter]()
-        self.strict_mode = strict_mode
+        self.context = TwaddleContext(
+            persistent_clipboard=persistent_clipboard,
+            persistent_labels=persistent_labels,
+            persistent_patterns=persistent_patterns,
+            persistent_synchronizers=persistent_synchronizers,
+            strict_mode=strict_mode,
+            lookup_manager=lookup_manager,
+        )
+        self.context.saved_patterns = dict[str, BlockNode]()
+        self.context.copied_blocks = dict[str, Formatter]()
 
     def interpret_external(self, sentence: str) -> str:
-        self.clear()
+        self.context.reset_for_new_sentence()
         try:
             tree = parser.parse(sentence)
             transformed_tree = transformer.transform(tree)
@@ -148,24 +148,6 @@ class Interpreter:
         result = formatter.resolve()
         return result
 
-    def clear(self):
-        if not self.persistent_labels:
-            self.context.lookup_manager.clear_labels()
-        if not self.persistent_synchronizers:
-            self.context.clear()
-        if not self.persistent_patterns:
-            self.saved_patterns.clear()
-        if not self.persistent_clipboard:
-            self.copied_blocks.clear()
-        self.context.consume_block_attributes()
-
-    def force_clear(self):
-        self.context.lookup_manager.clear_labels()
-        self.context.clear()
-        self.saved_patterns.clear()
-        self.context.block_attributes = BlockAttributes()
-        self.copied_blocks.clear()
-
     def _get_synchronizer_for_block(
         self, attributes: BlockAttributes, num_choices: int
     ) -> Optional[Synchronizer]:
@@ -173,7 +155,7 @@ class Interpreter:
             return None
         if self.context.synchronizer_exists(attributes.synchronizer):
             synchronizer = self.context.get_synchronizer(attributes.synchronizer)
-            if self.strict_mode and synchronizer.num_choices != num_choices:
+            if self.context.strict_mode and synchronizer.num_choices != num_choices:
                 raise TwaddleInterpreterException(
                     f"[Interpreter._get_synchronizer_for_block] Invalid number of choices ({num_choices}) "
                     f"for synchronizer '{attributes.synchronizer}', initialised with {synchronizer.num_choices}"
@@ -256,9 +238,9 @@ class Interpreter:
                 formatter.append_formatter(self.run(attributes.separator))
 
         if name := attributes.save_as:
-            self.saved_patterns[name] = block
+            self.context.saved_patterns[name] = block
         if name := attributes.copy_as:
-            self.copied_blocks[name] = copy(formatter)
+            self.context.copied_blocks[name] = copy(formatter)
         if attributes.hidden:
             return Formatter()
         if attributes.reverse:
@@ -300,7 +282,7 @@ class Interpreter:
     def _handle_special_functions(self, func: FunctionNode):
         match func.func:
             case "clear":
-                self.force_clear()
+                self.context.force_clear()
                 return Formatter()
             case "load":
                 evaluated_args = [self.run(arg).resolve() for arg in func.args]
@@ -317,7 +299,7 @@ class Interpreter:
                 )
 
     def _save_pattern(self, block: BlockNode, name: str):
-        self.saved_patterns[name] = block
+        self.context.saved_patterns[name] = block
 
     def _load_pattern(self, evaluated_args: list[str]) -> Formatter:
         if not len(evaluated_args):
@@ -325,7 +307,7 @@ class Interpreter:
                 "[Interpreter._handle_special_functions] Tried "
                 "to load pattern without specifying name"
             )
-        if not (block := self.saved_patterns.get(evaluated_args[0])):
+        if not (block := self.context.saved_patterns.get(evaluated_args[0])):
             if len(evaluated_args) > 1:
                 return Formatter.from_text(evaluated_args[1])
             raise TwaddleInterpreterException(
@@ -340,7 +322,7 @@ class Interpreter:
                 "[Interpreter._handle_special_functions] Tried "
                 "to paste block result without specifying name"
             )
-        if not (block := self.copied_blocks.get(evaluated_args[0])):
+        if not (block := self.context.copied_blocks.get(evaluated_args[0])):
             if len(evaluated_args) > 1:
                 return Formatter.from_text(evaluated_args[1])
             raise TwaddleInterpreterException(
@@ -388,7 +370,7 @@ class Interpreter:
     def _(self, lookup: LookupNode):
         formatter = Formatter()
         dictionary: LookupDictionary = self.context.lookup_manager[lookup.dictionary]
-        formatter.append(dictionary.get(lookup, self.strict_mode))
+        formatter.append(dictionary.get(lookup, self.context.strict_mode))
         return formatter
 
     # noinspection SpellCheckingInspection
@@ -408,7 +390,7 @@ class Interpreter:
         # noinspection SpellCheckingInspection
 
         def repl(matchobj: Match[str]):
-            RegexState.match = matchobj.group()
+            self.context.current_regex_match = matchobj.group()
             return self.run(regex.replacement).resolve()
 
         return Formatter.from_text(

--- a/twaddle/interpreter/interpreter.py
+++ b/twaddle/interpreter/interpreter.py
@@ -5,12 +5,13 @@ from re import Match, sub
 from typing import Optional
 
 from twaddle.exceptions import TwaddleInterpreterException
-from twaddle.interpreter.block_attributes import BlockAttributeManager, BlockAttributes
+from twaddle.interpreter.block_attributes import BlockAttributes
+from twaddle.interpreter.context import TwaddleContext
 from twaddle.interpreter.formatter import Formatter
 from twaddle.interpreter.function_definitions import boolean_helper
 from twaddle.interpreter.function_dict import function_definitions
 from twaddle.interpreter.regex_state import RegexState
-from twaddle.interpreter.synchronizer import Synchronizer, SynchronizerManager
+from twaddle.interpreter.synchronizer import Synchronizer
 from twaddle.lookup.lookup_dictionary import LookupDictionary
 from twaddle.lookup.lookup_manager import LookupManager
 from twaddle.parser.nodes import (
@@ -91,13 +92,12 @@ class Interpreter:
         persistent_clipboard: bool = False,
         strict_mode: bool = False,
     ):
+        self.context = TwaddleContext(lookup_manager=lookup_manager)
         self.persistent_labels = persistent_labels
         self.persistent_synchronizers = persistent_synchronizers
         self.persistent_patterns = persistent_patterns
         self.persistent_clipboard = persistent_clipboard
-        self.lookup_manager = lookup_manager
-        self.synchronizer_manager = SynchronizerManager()
-        self.block_attribute_manager = BlockAttributeManager()
+        self.context.lookup_manager = lookup_manager
         self.saved_patterns = dict[str, BlockNode]()
         self.copied_blocks = dict[str, Formatter]()
         self.strict_mode = strict_mode
@@ -150,20 +150,20 @@ class Interpreter:
 
     def clear(self):
         if not self.persistent_labels:
-            self.lookup_manager.clear_labels()
+            self.context.lookup_manager.clear_labels()
         if not self.persistent_synchronizers:
-            self.synchronizer_manager.clear()
+            self.context.clear()
         if not self.persistent_patterns:
             self.saved_patterns.clear()
         if not self.persistent_clipboard:
             self.copied_blocks.clear()
-        self.block_attribute_manager.clear()
+        self.context.consume_block_attributes()
 
     def force_clear(self):
-        self.lookup_manager.clear_labels()
-        self.synchronizer_manager.clear()
+        self.context.lookup_manager.clear_labels()
+        self.context.clear()
         self.saved_patterns.clear()
-        self.block_attribute_manager.clear()
+        self.context.block_attributes = BlockAttributes()
         self.copied_blocks.clear()
 
     def _get_synchronizer_for_block(
@@ -171,10 +171,8 @@ class Interpreter:
     ) -> Optional[Synchronizer]:
         if attributes.synchronizer is None:
             return None
-        if self.synchronizer_manager.synchronizer_exists(attributes.synchronizer):
-            synchronizer = self.synchronizer_manager.get_synchronizer(
-                attributes.synchronizer
-            )
+        if self.context.synchronizer_exists(attributes.synchronizer):
+            synchronizer = self.context.get_synchronizer(attributes.synchronizer)
             if self.strict_mode and synchronizer.num_choices != num_choices:
                 raise TwaddleInterpreterException(
                     f"[Interpreter._get_synchronizer_for_block] Invalid number of choices ({num_choices}) "
@@ -186,7 +184,7 @@ class Interpreter:
                 "[Interpreter.run](RantBlockObject) tried to define new synchronizer "
                 "without defining synchronizer type"
             )
-        return self.synchronizer_manager.create_synchronizer(
+        return self.context.create_synchronizer(
             attributes.synchronizer,
             attributes.synchronizer_type,
             num_choices,
@@ -210,7 +208,7 @@ class Interpreter:
     @run.register(BlockNode)
     def _(self, block: BlockNode):
         formatter = Formatter()
-        attributes: BlockAttributes = self.block_attribute_manager.get_attributes()
+        attributes: BlockAttributes = self.context.consume_block_attributes()
         if attributes.repetitions > 1 and attributes.while_predicate:
             raise TwaddleInterpreterException(
                 "Cannot apply repeat and while to same block "
@@ -374,9 +372,7 @@ class Interpreter:
         evaluated_args = [self.run(arg).resolve() for arg in func.args]
         if func.func in function_definitions:
             formatter.append(
-                function_definitions[func.func](
-                    evaluated_args, self.block_attribute_manager, func.args
-                )
+                function_definitions[func.func](evaluated_args, self.context, func.args)
             )
         else:
             raise TwaddleInterpreterException(
@@ -391,7 +387,7 @@ class Interpreter:
     @run.register(LookupNode)
     def _(self, lookup: LookupNode):
         formatter = Formatter()
-        dictionary: LookupDictionary = self.lookup_manager[lookup.dictionary]
+        dictionary: LookupDictionary = self.context.lookup_manager[lookup.dictionary]
         formatter.append(dictionary.get(lookup, self.strict_mode))
         return formatter
 

--- a/twaddle/interpreter/regex_state.py
+++ b/twaddle/interpreter/regex_state.py
@@ -1,2 +1,0 @@
-class RegexState:
-    match = str("")

--- a/twaddle/interpreter/synchronizer.py
+++ b/twaddle/interpreter/synchronizer.py
@@ -1,8 +1,6 @@
 from abc import ABC, abstractmethod
 from random import randrange, shuffle
 
-from twaddle.exceptions import TwaddleInterpreterException
-
 
 class Synchronizer(ABC):
     def __init__(self, num_choices: int):
@@ -58,32 +56,8 @@ class CyclicDeckSynchronizer(Synchronizer):
         return self.deck[self.pos]
 
 
-class SynchronizerManager:
-
-    sync_types = {
-        "locked": LockedSynchronizer,
-        "deck": DeckSynchronizer,
-        "cdeck": CyclicDeckSynchronizer,
-    }
-
-    def __init__(self):
-        self.synchronizers = dict[str, Synchronizer]()
-
-    def synchronizer_exists(self, name: str) -> bool:
-        return name in self.synchronizers
-
-    def create_synchronizer(
-        self, name: str, sync_type: str, length: int
-    ) -> Synchronizer:
-        self.synchronizers[name] = SynchronizerManager.sync_types[sync_type](length)
-        return self.synchronizers[name]
-
-    def get_synchronizer(self, name: str) -> Synchronizer:
-        if not self.synchronizer_exists(name):
-            raise TwaddleInterpreterException(
-                f"[SynchronizerManager.get_synchronizer] tried to access non-existing synchronizer {name}"
-            )
-        return self.synchronizers[name]
-
-    def clear(self):
-        self.synchronizers.clear()
+sync_types = {
+    "locked": LockedSynchronizer,
+    "deck": DeckSynchronizer,
+    "cdeck": CyclicDeckSynchronizer,
+}

--- a/twaddle/runner.py
+++ b/twaddle/runner.py
@@ -89,4 +89,4 @@ class TwaddleRunner:
         return self.interpreter.interpret_external(sentence)
 
     def clear(self) -> None:
-        self.interpreter.force_clear()
+        self.interpreter.context.force_clear()

--- a/twaddle/tests/interpreter/test_interpreter.py
+++ b/twaddle/tests/interpreter/test_interpreter.py
@@ -194,7 +194,7 @@ def test_clear_synchronizer_persistence():
     sync_interpreter = Interpreter(LookupManager(), persistent_synchronizers=True)
     results = [sync_interpreter.interpret_external("[sync:test;locked]{a|b|c}")]
     for _ in range(0, 10):
-        sync_interpreter.force_clear()
+        sync_interpreter.context.force_clear()
         results.append(sync_interpreter.interpret_external("[sync:test;locked]{a|b|c}"))
     assert len(set(results)) > 1
 

--- a/twaddle/tests/interpreter/test_synchronizer.py
+++ b/twaddle/tests/interpreter/test_synchronizer.py
@@ -1,14 +1,14 @@
+from twaddle.interpreter.context import TwaddleContext
 from twaddle.interpreter.synchronizer import (
     CyclicDeckSynchronizer,
     DeckSynchronizer,
     LockedSynchronizer,
-    SynchronizerManager,
 )
 
 
 def test_synchronizer_manager():
-    sync_manager = SynchronizerManager()
-    locked = sync_manager.create_synchronizer("x", "locked", 1)
+    context = TwaddleContext()
+    locked = context.create_synchronizer("x", "locked", 1)
     assert isinstance(locked, LockedSynchronizer)
 
 
@@ -21,7 +21,7 @@ def test_locked_synchronizer():
 
 def test_deck_synchronizer():
     deck = DeckSynchronizer(10)
-    results = dict[int:int]()
+    results = dict[int, int]()
     for value in range(0, 10):
         results[value] = 0
     for _ in range(0, 20):


### PR DESCRIPTION
## Summary

Introduces `TwaddleContext`, a single dataclass that consolidates all mutable interpreter state that was previously scattered across several independent manager objects and `Interpreter` instance variables.

## What changed

### New: `twaddle/interpreter/context.py`
`TwaddleContext` is a dataclass that owns all interpreter state:
- `lookup_manager` — dictionary lookups and label tracking
- `block_attributes` — attributes for the next block to be executed (repetitions, separator, first/last, synchronizer, hide, reverse, save/copy, abbreviate, while predicate)
- `synchronizers` — named synchronizer instances, with `synchronizer_exists`, `create_synchronizer`, `get_synchronizer`, and `clear_synchronizers` methods
- `saved_patterns` / `copied_blocks` — save/load and copy/paste stores
- `strict_mode` — strict validation flag
- `current_regex_match` — the current `[match]` value during regex replacement (previously a class-level global on `RegexState`)
- `reset_for_new_sentence()` / `force_clear()` — lifecycle methods replacing the scattered `clear()` / `force_clear()` logic in `Interpreter`
- `consume_block_attributes()` — atomically returns and resets the current block attributes

### Removed: `BlockAttributeManager`, `SynchronizerManager`, `RegexState`
These three classes existed solely to manage a piece of state that is now a field on `TwaddleContext`. Their logic has been folded in:
- `BlockAttributeManager.get_attributes()` → `TwaddleContext.consume_block_attributes()`
- `SynchronizerManager.*` → methods on `TwaddleContext`
- `RegexState.match` (class-level global) → `TwaddleContext.current_regex_match` (instance field)
- `BlockAttributes` is now a plain `@dataclass` rather than requiring a manager wrapper

### Updated: `Interpreter`, `function_definitions`, `runner`, tests
- `Interpreter.__init__` constructs one `TwaddleContext` instead of initialising five separate fields/managers
- All function definitions receive `TwaddleContext` instead of `BlockAttributeManager`, letting them write directly to `context.block_attributes`
- `interpreter.clear()` / `force_clear()` delegate to `context.reset_for_new_sentence()` / `context.force_clear()`
- Synchronizer tests updated to use the `sync_types` dict directly rather than `SynchronizerManager`

## Benefits

- **Single source of truth** — all interpreter state lives in one place. Understanding what state the interpreter holds no longer requires tracing through `Interpreter`, `BlockAttributeManager`, `SynchronizerManager`, and `RegexState` separately.
- **No more global/class-level state** — `RegexState.match` was a class variable shared across all interpreter instances, making concurrent or nested use unsafe. `current_regex_match` is now a proper instance field on the context.
- **Simpler function signature** — function definitions previously accepted `BlockAttributeManager`; they now accept `TwaddleContext`, which is the natural owner of all state they may need to read or modify.
- **Cleaner lifecycle** — sentence-level reset logic was duplicated across `Interpreter.clear()` and `force_clear()` with manual per-flag conditionals. This is now encapsulated in `reset_for_new_sentence()` and `force_clear()` on the context.
- **Easier to extend** — adding new interpreter state (e.g. a call stack, a variable store) means adding one field to `TwaddleContext` rather than creating yet another manager class and threading it through every call site.